### PR TITLE
Do not act on multitouch

### DIFF
--- a/TwoWayRecyclerView/genericepg/src/main/java/genericepg/duna/project/view/EPGView.java
+++ b/TwoWayRecyclerView/genericepg/src/main/java/genericepg/duna/project/view/EPGView.java
@@ -179,13 +179,17 @@ public class EPGView extends RelativeLayout {
         }
     }
 
-    //TODO fix the crash when tapping with more than one finger
     @Override
     public boolean dispatchTouchEvent(MotionEvent ev) {
         //manual dispatch events to specific view hierarchy
-        dispatchEventForView(ev, timelineRecyclerView);
-        dispatchEventForView(ev, epgRecyclerView);
-        dispatchEventForView(ev, channelsRecyclerView);
+        // ACTION_POINTER_DOWN -> fired when second finger touches the screen
+        // ACTION_POINTER_UP -> fired when second finger is lifted
+        if ((ev.getActionMasked() != MotionEvent.ACTION_POINTER_DOWN)
+                && (ev.getActionMasked() != MotionEvent.ACTION_POINTER_UP)) {
+            dispatchEventForView(ev, timelineRecyclerView);
+            dispatchEventForView(ev, epgRecyclerView);
+            dispatchEventForView(ev, channelsRecyclerView);
+        }
 
         nowTextView.getLocationInWindow(location);
         Rect editTextRect = new Rect();


### PR DESCRIPTION
ACTION_POINTER_DOWN -> fired when second finger touches the screen
ACTION_POINTER_UP -> fired when second finger is lifted
These 2 events will fire as soon as user initiates multitouch. So we have to discard these events.